### PR TITLE
修复0803版在Linux下使用异常的问题

### DIFF
--- a/NewLife.IP/IpDatabase.cs
+++ b/NewLife.IP/IpDatabase.cs
@@ -74,7 +74,7 @@ public class IpDatabase : IDisposable
         using var view = _mmf.CreateViewAccessor();
         Start = view.ReadUInt32(0);
         End = view.ReadUInt32(4);
-        Count = (End - Start) / 7u + 1u;
+        Count = (End - Start) / 7u;
 
         XTrace.WriteLine("IP记录数：{0:n0}", Count);
 

--- a/XUnitTest/IpTests.cs
+++ b/XUnitTest/IpTests.cs
@@ -26,43 +26,43 @@ public class IpTests
     {
         var addr = "39.144.10.35".IPToAddress();
         var ss = addr.Split(' ');
-        Assert.Equal("广东省", ss[0]);
+        Assert.Equal("中国–广东", ss[0]);
 
         addr = "116.234.91.199".IPToAddress();
         ss = addr.Split(' ');
-        Assert.Equal("上海市", ss[0]);
+        Assert.Equal("中国–上海–上海", ss[0]);
 
         addr = "61.160.219.25".IPToAddress();
         ss = addr.Split(' ');
-        Assert.Equal("江苏省常州市武进区", ss[0]);
+        Assert.Equal("中国–江苏–常州–武进区", ss[0]);
 
         addr = "123.14.85.208".IPToAddress();
         ss = addr.Split(' ');
-        Assert.Equal("河南省郑州市", ss[0]);
+        Assert.Equal("中国–河南–郑州", ss[0]);
 
         addr = "113.220.60.29".IPToAddress();
         ss = addr.Split(' ');
-        Assert.Equal("湖南省邵阳市", ss[0]);
+        Assert.Equal("中国–湖南–邵阳", ss[0]);
 
         addr = "124.239.170.77".IPToAddress();
         ss = addr.Split(' ');
-        Assert.Equal("河北省衡水市", ss[0]);
+        Assert.Equal("中国–河北–衡水", ss[0]);
 
         addr = "112.74.79.65".IPToAddress();
         ss = addr.Split(' ');
-        Assert.Equal("广东省深圳市", ss[0]);
+        Assert.Equal("中国–广东–深圳", ss[0]);
 
         addr = "218.87.90.59".IPToAddress();
         ss = addr.Split(' ');
-        Assert.Equal("江西省九江市永修县", ss[0]);
+        Assert.Equal("中国–江西–九江–永修县", ss[0]);
 
         addr = "39.144.8.87".IPToAddress();
         ss = addr.Split(' ');
-        Assert.Equal("广东省深圳市", ss[0]);
+        Assert.Equal("中国–广东–深圳", ss[0]);
 
         addr = "111.55.141.170".IPToAddress();
         ss = addr.Split(' ');
-        Assert.Equal("山西省", ss[0]);
+        Assert.Equal("中国–山西", ss[0]);
     }
 
     [Fact]
@@ -70,7 +70,7 @@ public class IpTests
     {
         var addr = "116.136.7.43".IPToAddress();
         var ss = addr.Split(' ');
-        Assert.Equal("内蒙古赤峰市", ss[0]);
+        Assert.Equal("中国–内蒙古–赤峰", ss[0]);
         Assert.Equal("", ss[1]);
     }
 }


### PR DESCRIPTION
#### 环境
    Windows X64 .Net 8.0

    Ubuntu X64 .Net 8.0

    Ubuntu Arm64 .Net 8.0


在windows下使用正常，当部署NewLife.IP（2.2.2024.803）到 Linux（X64/Arm64）下时会出现异常，复现代码如下

```
Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
IpResolver.Register();
XTrace.WriteLine("114.114.114.114".IPToAddress());
XTrace.WriteLine("114.114.114.114".ToUInt32IP().ToAddress().GetAddress());
```

异常信息如下

```
23:43:51.595  1 N - NewLife.Core v10.10.2024.0803 Build 2024-08-03 .NET 8.0
23:43:51.602  1 N - NewLife组件核心库 ©2002-2024 NewLife
23:43:51.602  1 N - Ip2AddressTest v1.0.0 Build 2000-01-01 .NET 8.0
23:43:51.602  1 N - Ip2AddressTest 
23:43:51.602  1 N - IP数据库：/root/ip/Data/ip.gz
23:43:51.889  1 N - IP记录数：1,463,859
23:43:52.033  1 N - System.ArgumentException: There are not enough bytes remaining in the accessor to read at this position. (Parameter 'position')
   at System.IO.UnmanagedMemoryAccessor.EnsureSafeToRead(Int64 position, Int32 sizeOfType)
   at System.IO.UnmanagedMemoryAccessor.ReadInt32(Int64 position)
   at NewLife.IP.IpDatabase.ReadIndexInfo(UnmanagedMemoryAccessor view, UInt32 index)
   at NewLife.IP.IpDatabase.GetAddress(UInt32 ip)
   at NewLife.IP.Ip.GetAddress(IPAddress ip)
   at NewLife.IP.IpResolver.GetAddress(IPAddress addr)
   at NewLife.NetHelper.GetAddress(IPAddress addr)
   at NewLife.NetHelper.IPToAddress(String addr)
   at Program.<Main>$(String[] args) in D:\NewLife\Ip2AddressTest\Program.cs:line 11
23:43:52.034  1 N - 异常退出！

```


调试后发现问题，以下方法在Linux下存在越界问题，而且是在读最后一条记录时发生

 **var p = Start + 7u * index;** 

https://github.com/NewLifeX/NewLife.IP/blob/87ea9bfbe296b93d79ff72b503627bf28a59da96/NewLife.IP/IpDatabase.cs#L199-L210

经过深入跟踪调试发现对于同一个地址库文件，在用**MMF**载入后使用方法 **CreateViewAccessor** 得到的 **Capacity** 是不相同的，

在Linux下数值是对的，在Windows下的数值偏大，当我们使用指定文件长度的方法时，

Windows和Linux下**Capacity** 的数值都是正确的，但在Linux下使用依然会报如上异常。复现代码如下

```
var fi = new FileInfo("./Data/ip.DAT".GetFullPath());
XTrace.WriteLine($"ip.DAT length {fi.Length}");
//ip.DAT length 25272339

var mmf = MemoryMappedFile.CreateFromFile("./Data/ip.DAT".GetFullPath(), FileMode.Open, null, 0, MemoryMappedFileAccess.ReadWrite);

using var viewWithoutLength = mmf.CreateViewAccessor();
XTrace.WriteLine($"ip.DAT view capacity viewWithoutLength {viewWithoutLength.Capacity}");
//ip.DAT view capacity viewWithoutLength 25276416  Windows
//ip.DAT view capacity viewWithoutLength 25272339  Linux

using var viewWithLength = mmf.CreateViewAccessor(0, fi.Length);
XTrace.WriteLine($"ip.DAT view capacity viewWithLength {viewWithLength.Capacity}");
//ip.DAT view capacity viewWithLength 25272339 Windows
//ip.DAT view capacity viewWithLength 25272339  Linux
```

如果不指定文件长度，此时在Windows下的 **Capacity** 应该是系统进行 **4K** 对齐了，因为 **25276416 / 4096 = 6171**

经过思考后想到IP数据库最后一条为

`1463858 255.255.255.000 255.255.255.255 纯真网络`

此记录为预留信息，现实中并无用处，异常又是读取最后一条记录时才触发，所以决定数据库数量不要加1

https://github.com/NewLifeX/NewLife.IP/blob/87ea9bfbe296b93d79ff72b503627bf28a59da96/NewLife.IP/IpDatabase.cs#L74-L79

经过此修改后编译测试 Windows 和 Linux下都使用正常。